### PR TITLE
Remove "tabs" permission for the addon

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -8,38 +8,4 @@ function scroll(tab) {
     });
 }
 
-function urlEnabled(url) {
-    return !(/^(?:about|data|moz-extension):/i.test(url) || isBlacklistedUrl(url));
-
-}
-
-function isBlacklistedUrl(url) {
-    const badDomains = ["addons.mozilla.org", "testpilot.firefox.com"];
-    let domain = url.replace(/^https?:\/\//i, "");
-    domain = domain.replace(/\/.*/, "").replace(/:.*/, "");
-    domain = domain.toLowerCase();
-    return badDomains.includes(domain);
-}
-
-function toggleAvailability(url, tabId) {
-    if (!urlEnabled(url)) {
-        browser.pageAction.hide(tabId);
-    } else {
-        browser.pageAction.show(tabId);
-    }
-}
-
-function tabActivated(activeInfo) {
-    browser.tabs.get(activeInfo.tabId)
-        .then(function (tab) {
-            toggleAvailability(tab.url, activeInfo.tabId);
-        });
-}
-
-function tabUpdated(tabId, changeInfo) {
-    toggleAvailability(changeInfo.url, tabId);
-}
-
-browser.tabs.onUpdated.addListener(tabUpdated);
-browser.tabs.onActivated.addListener(tabActivated);
 browser.pageAction.onClicked.addListener(scroll);

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -9,13 +9,15 @@
     "32": "icons/icon-32.png"
   },
   "homepage_url": "https://github.com/odnari/tabScrollTop2",
-  "permissions": [
-    "activeTab",
-    "tabs"
-  ],
+  "permissions": ["activeTab"],
   "page_action": {
     "default_icon": "icons/icon-32.png",
-    "default_title": "Scroll up/down"
+    "default_title": "Scroll up/down",
+    "show_matches": ["<all_urls>"],
+    "hide_matches": [
+      "*://addons.mozilla.org/*",
+      "*://testpilot.firefox.com/*"
+    ]
   },
   "background": {
     "scripts": ["background.js"]


### PR DESCRIPTION
The version of the addon in this repository differs from that published on addons.mozilla.org and it doesn't seem to have any problems with proper showing/hiding the action button. Still I'll propose these changes since they allow to get rid of `tabs` permission for the addon and do less work in the addon itself while maintaining the same functionality.

Actually there are two reasons behind the proposed changes:
1. We don't need to test URLs manually for switching availability of the button as we can define `show_matches` and `hide_matches` entries for that (see [Mozilla docs](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/page_action#Syntax)). This allows us also not to use `tabs` permission for this addon to work.
2. `<all_urls>` pattern doesn't include some special URLs like `about:` and `moz-extension:` schemes (and probably shouldn't according to [the documentation](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/Match_patterns#%3Call_urls%3E)) so I didn't include a special check for them in the proposed version of manifest. Still I had to leave entries for some restricted domains in `hide_matches` for the button as they seem to be not filtered out automatically by Firefox.